### PR TITLE
Update FCS to fix a rare crash.

### DIFF
--- a/autumn/natives/fcs/build.gradle
+++ b/autumn/natives/fcs/build.gradle
@@ -1,5 +1,5 @@
 ext {
-  fcsVersion = '2.0.4'
+  fcsVersion = '2.21'
 }
 
 dependencies {


### PR DESCRIPTION
At least one Ubuntu 20.04.3 LTS machine was unable to open an otherwise valid JAR using autumn's fast classpath scanner, and I tracked it down to the older version of FCS that gdx-lml still uses. I had updated it previously, which had fixed it for me, until I switched my dependencies all to the crashinvaders fork. That brought FCS down to version 2.0.4 when it has been 2.21 before, and started the crashes for the Ubuntu machine. The crashes happened every time at startup, regardless of what classpath scanner was used.

This is not a complex fix (one line of Gradle), so it doesn't really need an issue reported -- we should just try to be up-to-date with dependencies as long as they maintain compatibility.