### PR TITLE
Messy 1.12.0 support and other code

### DIFF
--- a/autumn/build.gradle
+++ b/autumn/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  compile project(':kiwi')
+  api project(':kiwi')
 }

--- a/autumn/natives/android/build.gradle
+++ b/autumn/natives/android/build.gradle
@@ -1,9 +1,15 @@
-ext {
-  androidVersion = '4.1.1.4'
+repositories {
+  mavenLocal()
+  mavenCentral()
+  maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+  maven { url "https://oss.sonatype.org/content/repositories/releases/" }
+  google()
 }
 
+sourceCompatibility = 8
+targetCompatibility = 8
+
 dependencies {
-  provided "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
-  provided "com.google.android:android:$androidVersion"
-  compile project(':autumn')
+  api "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
+  api project(':autumn')
 }

--- a/autumn/natives/fcs/build.gradle
+++ b/autumn/natives/fcs/build.gradle
@@ -1,8 +1,8 @@
 ext {
-  fcsVersion = '2.21'
+  classgraphVersion = '4.8.138'
 }
 
 dependencies {
-  compile project(':autumn')
-  compile "io.github.lukehutch:fast-classpath-scanner:$fcsVersion"
+  implementation project(':autumn')
+  implementation "io.github.classgraph:classgraph:$classgraphVersion"
 }

--- a/autumn/natives/fcs/build.gradle
+++ b/autumn/natives/fcs/build.gradle
@@ -1,8 +1,9 @@
+apply plugin: 'java-library'
 ext {
-  classgraphVersion = '4.8.138'
+  fcsVersion = '2.21'
 }
 
 dependencies {
-  implementation project(':autumn')
-  implementation "io.github.classgraph:classgraph:$classgraphVersion"
+  api project(':autumn')
+  implementation "io.github.lukehutch:fast-classpath-scanner:$fcsVersion"
 }

--- a/autumn/natives/fcs/src/main/java/com/github/czyzby/autumn/fcs/scanner/DesktopClassScanner.java
+++ b/autumn/natives/fcs/src/main/java/com/github/czyzby/autumn/fcs/scanner/DesktopClassScanner.java
@@ -8,35 +8,40 @@ import com.github.czyzby.autumn.AutumnRoot;
 import com.github.czyzby.autumn.scanner.ClassScanner;
 import com.github.czyzby.kiwi.util.gdx.collection.GdxArrays;
 import com.github.czyzby.kiwi.util.gdx.collection.GdxSets;
-
-import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
-import io.github.lukehutch.fastclasspathscanner.matchprocessor.ClassAnnotationMatchProcessor;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
 
 /** Default, efficient class scanner for desktop. Does not rely on reflection and does not load scanned classes. Uses
- * {@link FastClasspathScanner} wrapped with and adapted to {@link ClassScanner} interface to serve as default class
+ * {@link ClassGraph} wrapped with and adapted to {@link ClassScanner} interface to serve as default class
  * scanner for desktop LibGDX applications using Autumn. If for some reason this scanner does not work for you, try
  * {@link com.github.czyzby.autumn.nongwt.scanner.FallbackDesktopClassScanner} (which is much slower, as it depends on
  * reflection) or {@link com.github.czyzby.autumn.scanner.FixedClassScanner} (which will force you to register class
  * pool to scan, sacrificing true component scanning).
  *
  * @author MJ
- * @see FastClasspathScanner */
+ * @author metaphore
+ * @see ClassGraph */
 public class DesktopClassScanner implements ClassScanner {
     @Override
     public Array<Class<?>> findClassesAnnotatedWith(final Class<?> root,
             final Iterable<Class<? extends Annotation>> annotations) {
+
+        ScanResult scanResult = new ClassGraph()
+//                .verbose()
+                .enableAnnotationInfo()
+                .acceptPackages(
+                        root.getPackage().getName(),
+                        AutumnRoot.class.getPackage().getName())
+                .scan();
+
         final ObjectSet<Class<?>> result = GdxSets.newSet(); // Using set to remove duplicates.
-        final FastClasspathScanner scanner = new FastClasspathScanner(root.getPackage().getName(),
-                AutumnRoot.class.getPackage().getName());
         for (final Class<? extends Annotation> annotation : annotations) {
-            scanner.matchClassesWithAnnotation(annotation, new ClassAnnotationMatchProcessor() {
-                @Override
-                public void processMatch(final Class<?> matchingClass) {
-                    result.add(matchingClass);
-                }
-            });
+            ClassInfoList matchingClasses = scanResult.getClassesWithAnnotation(annotation);
+            for (Class<?> matchingClass : matchingClasses.loadClasses()) {
+                result.add(matchingClass);
+            }
         }
-        scanner.scan();
         return GdxArrays.newArray(result);
     }
 }

--- a/autumn/src/main/java/com/github/czyzby/autumn/nongwt/scanner/FallbackDesktopClassScanner.java
+++ b/autumn/src/main/java/com/github/czyzby/autumn/nongwt/scanner/FallbackDesktopClassScanner.java
@@ -10,6 +10,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.regex.Pattern;
 
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -100,14 +101,14 @@ public class FallbackDesktopClassScanner implements ClassScanner {
     }
 
     private static String getBinaryClassName(final String mainPackageName, final File classPathFile, final int depth) {
-        final String[] classFolders = classPathFile.getPath().split(File.separator);
+        final String[] classFolders = classPathFile.getPath().split(Pattern.quote(File.separator));
         final StringBuilder builder = new StringBuilder(mainPackageName);
         for (int folderIndex = classFolders.length - depth; folderIndex < classFolders.length - 1; folderIndex++) {
             builder.append(DOT_SEPARATOR).append(classFolders[folderIndex]);
         }
         final String classFileName = classFolders[classFolders.length - 1];
         builder.append(DOT_SEPARATOR)
-                .append(classFileName.substring(0, classFileName.length() - CLASS_FILE_EXTENSION.length()));
+                .append(classFileName, 0, classFileName.length() - CLASS_FILE_EXTENSION.length());
         return builder.toString();
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ allprojects {
 
   ext {
     projectVersion = '1.10'
-    gdxVersion = '1.11.0'
-    isSnapshot = false
+    gdxVersion = '1.12.0'
+    isSnapshot = true
     libVersion = "$projectVersion.$gdxVersion${isSnapshot ? '-SNAPSHOT' : ''}"
   }
 }
@@ -48,7 +48,7 @@ configure(libModules) {
 
   ext {
     wagonVersion = '2.10'
-    junitVersion = '4.12'
+    junitVersion = '4.13.2'
   }
 
   repositories {
@@ -56,10 +56,11 @@ configure(libModules) {
     mavenCentral()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     maven { url "https://oss.sonatype.org/content/repositories/releases/" }
+    google()
   }
 
-  sourceCompatibility = 1.7
-  targetCompatibility = 1.7
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
   group = 'com.crashinvaders.lml'
   version = libVersion
   archivesBaseName = projectName

--- a/examples/gdx-autumn-mvc-simple/android/build.gradle
+++ b/examples/gdx-autumn-mvc-simple/android/build.gradle
@@ -88,8 +88,8 @@ eclipse {
     }
 
     jdt {
-        sourceCompatibility = 1.7
-        targetCompatibility = 1.7
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
     }
 
     classpath {

--- a/examples/gdx-autumn-mvc-simple/core/build.gradle
+++ b/examples/gdx-autumn-mvc-simple/core/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/examples/gdx-autumn-mvc-simple/desktop/build.gradle
+++ b/examples/gdx-autumn-mvc-simple/desktop/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = [ "../android/assets/" ]
 

--- a/examples/gdx-autumn-mvc-simple/html/build.gradle
+++ b/examples/gdx-autumn-mvc-simple/html/build.gradle
@@ -61,7 +61,7 @@ task addSource << {
 tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 

--- a/examples/gdx-autumn-tests/core/build.gradle
+++ b/examples/gdx-autumn-tests/core/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/examples/gdx-autumn-tests/desktop/build.gradle
+++ b/examples/gdx-autumn-tests/desktop/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = [ "../core/assets/" ]
 

--- a/examples/gdx-autumn-tests/html/build.gradle
+++ b/examples/gdx-autumn-tests/html/build.gradle
@@ -61,7 +61,7 @@ task addSource << {
 tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 

--- a/examples/gdx-lml-tests/build.gradle
+++ b/examples/gdx-lml-tests/build.gradle
@@ -18,7 +18,7 @@ allprojects {
 
 configure(subprojects) {
   apply plugin: 'java'
-  sourceCompatibility = 1.7
+  sourceCompatibility = 1.8
 }
 
 subprojects {

--- a/examples/gdx-lml-tests/desktop/build.gradle
+++ b/examples/gdx-lml-tests/desktop/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'application'
 sourceSets.main.resources.srcDirs += [ rootProject.file('assets').absolutePath ]
 mainClassName = 'com.github.czyzby.tests.desktop.DesktopLauncher'
 eclipse.project.name = appName + '-desktop'
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 dependencies {
   compile project(':core')

--- a/examples/gdx-lml-uedi-tests/android/build.gradle
+++ b/examples/gdx-lml-uedi-tests/android/build.gradle
@@ -111,8 +111,8 @@ eclipse {
   }
 
   jdt {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
   }
 
   classpath {

--- a/examples/gdx-lml-uedi-tests/build.gradle
+++ b/examples/gdx-lml-uedi-tests/build.gradle
@@ -19,7 +19,7 @@ allprojects {
 
 configure(subprojects - project(':android')) {
   apply plugin: 'java'
-  sourceCompatibility = 1.7
+  sourceCompatibility = 1.8
 }
 
 subprojects {

--- a/examples/gdx-lml-uedi-tests/desktop/build.gradle
+++ b/examples/gdx-lml-uedi-tests/desktop/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'application'
 sourceSets.main.resources.srcDirs += [ rootProject.file('assets').absolutePath ]
 mainClassName = 'com.github.czyzby.tests.desktop.DesktopLauncher'
 eclipse.project.name = appName + '-desktop'
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 dependencies {
   compile project(':core')

--- a/examples/gdx-lml-vis-tests/build.gradle
+++ b/examples/gdx-lml-vis-tests/build.gradle
@@ -18,7 +18,7 @@ allprojects {
 
 configure(subprojects) {
   apply plugin: 'java'
-  sourceCompatibility = 1.7
+  sourceCompatibility = 1.8
 }
 
 subprojects {

--- a/examples/gdx-lml-vis-tests/desktop/build.gradle
+++ b/examples/gdx-lml-vis-tests/desktop/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'application'
 sourceSets.main.resources.srcDirs += [ rootProject.file('assets').absolutePath ]
 mainClassName = 'com.github.czyzby.tests.desktop.DesktopLauncher'
 eclipse.project.name = appName + '-desktop'
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 dependencies {
   compile project(':core')

--- a/examples/gdx-lml-vis-websocket/core/build.gradle
+++ b/examples/gdx-lml-vis-websocket/core/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/examples/gdx-lml-vis-websocket/desktop/build.gradle
+++ b/examples/gdx-lml-vis-websocket/desktop/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = [ "../core/assets/" ]
 

--- a/examples/gdx-lml-vis-websocket/html/build.gradle
+++ b/examples/gdx-lml-vis-websocket/html/build.gradle
@@ -61,7 +61,7 @@ task addSource << {
 tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 

--- a/examples/gdx-lml-vis-wiki/core/build.gradle
+++ b/examples/gdx-lml-vis-wiki/core/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/examples/gdx-lml-vis-wiki/desktop/build.gradle
+++ b/examples/gdx-lml-vis-wiki/desktop/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = [ "../core/assets" ]
 

--- a/examples/gdx-lml-vis-wiki/html/build.gradle
+++ b/examples/gdx-lml-vis-wiki/html/build.gradle
@@ -61,7 +61,7 @@ task addSource << {
 tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 

--- a/examples/gdx-websocket-json/core/build.gradle
+++ b/examples/gdx-websocket-json/core/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/examples/gdx-websocket-json/desktop/build.gradle
+++ b/examples/gdx-websocket-json/desktop/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 project.ext.mainClassName = "com.github.czyzby.desktop.DesktopLauncher"

--- a/examples/gdx-websocket-json/html/build.gradle
+++ b/examples/gdx-websocket-json/html/build.gradle
@@ -62,7 +62,7 @@ task addSource << {
 tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 eclipse.project {

--- a/examples/gdx-websocket-json/shared/build.gradle
+++ b/examples/gdx-websocket-json/shared/build.gradle
@@ -1,4 +1,4 @@
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 eclipse.project {

--- a/examples/gdx-websocket-serialization-compare/core/build.gradle
+++ b/examples/gdx-websocket-serialization-compare/core/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/examples/gdx-websocket-serialization-compare/desktop/build.gradle
+++ b/examples/gdx-websocket-serialization-compare/desktop/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = [ "../core/assets/" ]
 

--- a/examples/gdx-websocket-serialization-compare/html/build.gradle
+++ b/examples/gdx-websocket-serialization-compare/html/build.gradle
@@ -62,7 +62,7 @@ task addSource << {
 tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 eclipse.project {

--- a/examples/gdx-websocket-serialization-compare/shared/build.gradle
+++ b/examples/gdx-websocket-serialization-compare/shared/build.gradle
@@ -1,4 +1,4 @@
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 eclipse.project {

--- a/examples/gdx-websocket-serialization-tests/core/build.gradle
+++ b/examples/gdx-websocket-serialization-tests/core/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/examples/gdx-websocket-serialization-tests/desktop/build.gradle
+++ b/examples/gdx-websocket-serialization-tests/desktop/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = [ "../core/assets/" ]
 

--- a/examples/gdx-websocket-serialization-tests/html/build.gradle
+++ b/examples/gdx-websocket-serialization-tests/html/build.gradle
@@ -62,7 +62,7 @@ task addSource << {
 tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 eclipse.project {

--- a/examples/gdx-websocket-serialization-tests/shared/build.gradle
+++ b/examples/gdx-websocket-serialization-tests/shared/build.gradle
@@ -1,4 +1,4 @@
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 eclipse.project {

--- a/examples/gdx-websocket-tests/core/build.gradle
+++ b/examples/gdx-websocket-tests/core/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/examples/gdx-websocket-tests/desktop/build.gradle
+++ b/examples/gdx-websocket-tests/desktop/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "java"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = [ "../core/assets/" ]
 

--- a/examples/gdx-websocket-tests/html/build.gradle
+++ b/examples/gdx-websocket-tests/html/build.gradle
@@ -61,7 +61,7 @@ task addSource << {
 tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 

--- a/kiwi/src/main/java/com/github/czyzby/kiwi/util/gdx/InputAwareApplicationAdapter.java
+++ b/kiwi/src/main/java/com/github/czyzby/kiwi/util/gdx/InputAwareApplicationAdapter.java
@@ -59,6 +59,11 @@ public class InputAwareApplicationAdapter implements ApplicationListener, InputP
     }
 
     @Override
+    public boolean touchCancelled(int screenX, int screenY, int pointer, int button) {
+        return false;
+    }
+
+    @Override
     public boolean touchDragged(final int screenX, final int screenY, final int pointer) {
         return false;
     }

--- a/lml-vis/build.gradle
+++ b/lml-vis/build.gradle
@@ -3,6 +3,6 @@ ext {
 }
 
 dependencies {
-  compile project(':lml')
-  compile "com.kotcrab.vis:vis-ui:$visVersion"
+  api project(':lml')
+  api "com.kotcrab.vis:vis-ui:$visVersion"
 }

--- a/lml/build.gradle
+++ b/lml/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  compile project(':kiwi')
+  api project(':kiwi')
 }

--- a/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellExpandXLmlAttribute.java
+++ b/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellExpandXLmlAttribute.java
@@ -17,13 +17,7 @@ public class CellExpandXLmlAttribute extends AbstractCellLmlAttribute {
     }
 
     protected boolean determineExpandY(final Cell<?> cell) {
-        try {
-            return cell.getExpandY() > 0;
-        } catch (final Exception exception) {
-            // LibGDX Scene2D method returns int, while the field is an Integer that might not have been initiated. This
-            // causes a NPE - so when an exception is thrown, we assume that the expand was not set.
-            Exceptions.ignore(exception);
-            return false;
-        }
+        Integer v = cell.getExpandY();
+        return v != null && v > 0;
     }
 }

--- a/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellExpandYLmlAttribute.java
+++ b/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellExpandYLmlAttribute.java
@@ -17,13 +17,7 @@ public class CellExpandYLmlAttribute extends AbstractCellLmlAttribute {
     }
 
     protected boolean determineExpandX(final Cell<?> cell) {
-        try {
-            return cell.getExpandX() > 0;
-        } catch (final Exception exception) {
-            // LibGDX Scene2D method returns int, while the field is an Integer that might not have been initiated. This
-            // causes a NPE - so when an exception is thrown, we assume that the expand was not set.
-            Exceptions.ignore(exception);
-            return false;
-        }
+        Integer v = cell.getExpandX();
+        return v != null && v > 0;
     }
 }

--- a/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellFillXLmlAttribute.java
+++ b/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellFillXLmlAttribute.java
@@ -17,13 +17,7 @@ public class CellFillXLmlAttribute extends AbstractCellLmlAttribute {
     }
 
     protected boolean determineFillY(final Cell<?> cell) {
-        try {
-            return cell.getFillY() > 0f;
-        } catch (final Exception exception) {
-            // LibGDX Scene2D method returns float, while the field is a Float that might not have been initiated. This
-            // causes a NPE - so when an exception is thrown, we assume that the fill was not set.
-            Exceptions.ignore(exception);
-            return false;
-        }
+        Float v = cell.getFillY();
+        return v != null && v > 0f;
     }
 }

--- a/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellFillYLmlAttribute.java
+++ b/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellFillYLmlAttribute.java
@@ -17,13 +17,7 @@ public class CellFillYLmlAttribute extends AbstractCellLmlAttribute {
     }
 
     protected boolean determineFillX(final Cell<?> cell) {
-        try {
-            return cell.getFillX() > 0f;
-        } catch (final Exception exception) {
-            // LibGDX Scene2D method returns float, while the field is a Float that might not have been initiated. This
-            // causes a NPE - so when an exception is thrown, we assume that the fill was not set.
-            Exceptions.ignore(exception);
-            return false;
-        }
+        Float v = cell.getFillX();
+        return v != null && v > 0f;
     }
 }

--- a/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellUniformXLmlAttribute.java
+++ b/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellUniformXLmlAttribute.java
@@ -17,13 +17,7 @@ public class CellUniformXLmlAttribute extends AbstractCellLmlAttribute {
     }
 
     protected boolean determineUniformY(final Cell<?> cell) {
-        try {
-            return cell.getUniformY();
-        } catch (final Exception exception) {
-            // LibGDX Scene2D method returns boolean, while the field is a Boolean that might not have been initiated.
-            // This causes a NPE - so when an exception is thrown, we assume that the uniform was not set.
-            Exceptions.ignore(exception);
-            return false;
-        }
+        Boolean v = cell.getUniformY();
+        return v != null && v;
     }
 }

--- a/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellUniformYLmlAttribute.java
+++ b/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/table/cell/CellUniformYLmlAttribute.java
@@ -17,13 +17,7 @@ public class CellUniformYLmlAttribute extends AbstractCellLmlAttribute {
     }
 
     protected boolean determineUniformX(final Cell<?> cell) {
-        try {
-            return cell.getUniformX();
-        } catch (final Exception exception) {
-            // LibGDX Scene2D method returns boolean, while the field is a Boolean that might not have been initiated.
-            // This causes a NPE - so when an exception is thrown, we assume that the uniform was not set.
-            Exceptions.ignore(exception);
-            return false;
-        }
+        Boolean v = cell.getUniformX();
+        return v != null && v;
     }
 }

--- a/mvc/build.gradle
+++ b/mvc/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-  compile project(':autumn')
-  compile project(':lml')
+  api project(':autumn')
+  api project(':lml')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include 'kiwi', 'lml', 'lml-vis',
-        'autumn', 'autumn:natives:android', 'autumn:natives:fcs', 'autumn:natives:gwt', 'autumn:natives:jtransc', 'mvc',
-        'websocket', 'websocket:natives:common', 'websocket:natives:gwt', 'websocket:natives:serialization',
+        'autumn', 'autumn:natives:fcs',
+//        'autumn:natives:android', 'autumn:natives:gwt', 'autumn:natives:jtransc',
+        'mvc', 'websocket', 'websocket:natives:common', 'websocket:natives:gwt', 'websocket:natives:serialization',
         'uedi'

--- a/uedi/build.gradle
+++ b/uedi/build.gradle
@@ -5,7 +5,7 @@ ext {
 dependencies {
   api project(':kiwi')
 
-  // Even so we forked LML to maintain it entirely, there seem to be no need
+  // Even though we forked LML to maintain it entirely, there seem to be no need
   // in forking archived uedi-api repo (https://github.com/crashinvaders/uedi)
   // as it's standalone header kinda lib.
   api "com.github.czyzby:uedi-api:$uediVersion"

--- a/uedi/build.gradle
+++ b/uedi/build.gradle
@@ -3,10 +3,10 @@ ext {
 }
 
 dependencies {
-  compile project(':kiwi')
+  api project(':kiwi')
 
   // Even so we forked LML to maintain it entirely, there seem to be no need
   // in forking archived uedi-api repo (https://github.com/crashinvaders/uedi)
   // as it's standalone header kinda lib.
-  compile "com.github.czyzby:uedi-api:$uediVersion"
+  api "com.github.czyzby:uedi-api:$uediVersion"
 }

--- a/websocket/natives/common/build.gradle
+++ b/websocket/natives/common/build.gradle
@@ -3,6 +3,6 @@ ext {
 }
 
 dependencies {
-  compile project(':websocket')
-  compile "com.neovisionaries:nv-websocket-client:$nvVersion"
+  api project(':websocket')
+  api "com.neovisionaries:nv-websocket-client:$nvVersion"
 }

--- a/websocket/natives/gwt/build.gradle
+++ b/websocket/natives/gwt/build.gradle
@@ -7,6 +7,6 @@ javadoc {
 }
 
 dependencies {
-  compile project(':websocket')
+  api project(':websocket')
   provided "com.google.gwt:gwt-user:$gwtVersion"
 }

--- a/websocket/natives/serialization/build.gradle
+++ b/websocket/natives/serialization/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-  compile project(':websocket')
+  api project(':websocket')
 }
 


### PR DESCRIPTION
The main thing this does is clean up some incompatibilities in the move to libGDX 1.12.0 . It comments out the classpath scanning modules for Android, GWT, and JTransc because I could not get the Android version to build (it seems extremely old), I don't think JTransc is maintained anymore, and I didn't feel like dealing with yet more GWT nonsense. This is unfortunately a mess because it includes my changes for FCS, which probably should be moved to a different module, and the already-fixed regex split bug. This updates to Java 8 all around because the soon-to-be-LTS Java 21 won't support targeting Java 7, and Java 20 (out now, just not usable with Gradle very easily) already doesn't allow targeting 7.

I don't mind if this PR doesn't get merged as-is; edits are allowed and encouraged, but you could also just pick out the 1.12.0 compatibility changes if you want, or revert the last two commits and then merge. This would really be helpful for supporting libGDX 1.12.0, but I also have a fork that I can use for my stuff in a pinch (it's currently what Liftoff uses).